### PR TITLE
Adding tests to types and allure-report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
-
+/allure-report
+/allure-results

--- a/Data/types.js
+++ b/Data/types.js
@@ -1,0 +1,52 @@
+export const TYPES = [
+    {
+        "name": "normal",
+        "doubleDamage": "fighting",
+        "immune": "ghost"
+    },
+    {
+        "name": "fighting",
+        "doubleDamage": "flying"
+    },
+    {
+        "name": "flying",
+        "doubleDamage": "rock",
+        "immune": "ground"
+    },
+    {
+        "name": "poison",
+        "doubleDamage": "ground"
+    },
+    {
+        "name": "ground",
+        "doubleDamage": "water",
+        "immune": "electric"
+    },
+    {
+        "name": "rock",
+        "doubleDamage": "fighting"
+    },
+    {
+        "name": "bug",
+        "doubleDamage": "flying"
+    },
+    {
+        "name": "ghost",
+        "doubleDamage": "ghost",
+        "immune": "normal"
+    },
+    {
+        "name": "steel",
+        "doubleDamage": "fighting",
+        "immune": "poison"
+    },
+    {
+        "name": "fire",
+        "doubleDamage": "ground",
+        "immune": " "
+    },
+    {
+        "name": "ice",
+        "doubleDamage": "fighting",
+    }
+]

--- a/Data/types.js
+++ b/Data/types.js
@@ -43,7 +43,6 @@ export const TYPES = [
     {
         "name": "fire",
         "doubleDamage": "ground",
-        "immune": " "
     },
     {
         "name": "ice",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.45.1",
-        "@types/node": "^20.14.9"
+        "@types/node": "^20.14.9",
+        "allure-playwright": "^3.0.0-beta.6"
       }
     },
     "node_modules/@playwright/test": {
@@ -37,6 +38,54 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/allure-js-commons": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.0.0-beta.6.tgz",
+      "integrity": "sha512-blkS1JG6kHSrplluBqrEcRvFHSaL1YTcN5w1IXpTnMAwPDluTfVAP2RYCWpeAzgELfAh5e/AMVWXt7wt6qKMXw==",
+      "dev": true,
+      "dependencies": {
+        "md5": "^2.3.0",
+        "properties": "^1.2.1"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.0.0-beta.6"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-playwright": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.0.0-beta.6.tgz",
+      "integrity": "sha512-tXJzwqW8fEugEczsdZAM7WIDjFaALGiaBg4aNqqmBXwf507Wq82Giwa8jlagGHsMQjdvjK+ZFP/Fo0Mt6COr4g==",
+      "dev": true,
+      "dependencies": {
+        "allure-js-commons": "3.0.0-beta.6"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.36.0"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -49,6 +98,23 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/playwright": {
@@ -79,6 +145,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz",
+      "integrity": "sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.45.1",
-    "@types/node": "^20.14.9"
+    "@types/node": "^20.14.9",
+    "allure-playwright": "^3.0.0-beta.6"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,7 +21,14 @@ module.exports = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html'],
+  ["allure-playwright",
+    {
+      detail: true,
+      outputFolder: "allure-results",
+      suiteTitle: false,
+    },]
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,13 +21,16 @@ module.exports = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['html'],
-  ["allure-playwright",
-    {
-      detail: true,
-      outputFolder: "allure-results",
-      suiteTitle: false,
-    },]
+  reporter: [
+    ['html'],
+    [
+      'allure-playwright',
+      {
+        detail: true,
+        outputFolder: 'allure-results',
+        suiteTitle: false,
+      },
+    ],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -40,7 +43,7 @@ module.exports = defineConfig({
 
   timeout: 900000,
   expect: {
-    timeout: 6000,
+    timeout: 12000,
   },
 
   /* Configure projects for major browsers */

--- a/tests/pokemon.spec.js
+++ b/tests/pokemon.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-test('Select Pokémon Bulbassaur', async ({ page }) => {
+test.skip('Select Pokémon Bulbassaur', async ({ page }) => {
   await page.goto('https://brunomachadors.github.io/pokedex/');
 
   await expect(page.getByLabel('POKÉMON Button')).toBeVisible();

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -58,18 +58,20 @@ test.describe('Verify in batch the correct display of type information', () => {
             await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
             await expect(page.getByRole('img', { name: icon }).first()).toBeVisible();
         });
+        const isImmune = type.immune ? true : false;
+        if (isImmune) {
+            test(`Validate that Immune to ${type.immune} is showed to ${type.name} type`, async ({ page }) => {
+                test.skip(type.immune == " " || type.immune == undefined);
+                await expect(page.getByLabel('Select Type')).toBeVisible();
+                await page.getByLabel(selectType).click();
+                await expect(page.getByLabel('Switch to Info')).toBeVisible();
+                await page.getByLabel('Switch to Info').click();
 
-        test(`Validate that Immune to ${type.immune} is showed to ${type.name} type`, async ({ page }) => {
-            test.skip(type.immune == " " || type.immune == undefined);
-            await expect(page.getByLabel('Select Type')).toBeVisible();
-            await page.getByLabel(selectType).click();
-            await expect(page.getByLabel('Switch to Info')).toBeVisible();
-            await page.getByLabel('Switch to Info').click();
-
-            await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toBeVisible();
-            await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
-            await expect(page.getByLabel(immune).getByText(type.immune.toUpperCase())).toContainText(type.immune.toUpperCase());
-        });
+                await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toBeVisible();
+                await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
+                await expect(page.getByLabel(immune).getByText(type.immune.toUpperCase())).toContainText(type.immune.toUpperCase());
+            });
+        }
     });
 });
 

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -1,0 +1,78 @@
+import { skip } from 'node:test';
+import { TYPES } from '../Data/types';
+
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('https://brunomachadors.github.io/pokedex/');
+    await expect(page.getByLabel('TYPES Button')).toBeVisible();
+    await page.getByLabel('TYPES Button').click();
+});
+
+test('Hard code - Validate that fighting icon Double Damage is showed to normal type', async ({ page }) => {
+    await expect(page.getByLabel('Select Type')).toBeVisible();
+    await page.getByLabel('Select the type normal').click();
+    await expect(page.getByLabel('Switch to Info')).toBeVisible();
+    await page.getByLabel('Switch to Info').click();
+
+    await expect(page.getByLabel('White Screen').getByText('NORMAL')).toBeVisible();
+    await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
+    await expect(page.getByRole('img', { name: 'fighting icon' })).toBeVisible();
+});
+
+test('Hard code - Validate that Immune to ghost is showed to normal type', async ({ page }) => {
+    await expect(page.getByLabel('Select Type')).toBeVisible();
+    await page.getByLabel('Select the type normal').click();
+    await expect(page.getByLabel('Switch to Info')).toBeVisible();
+    await page.getByLabel('Switch to Info').click();
+
+    await expect(page.getByLabel('White Screen').getByText('NORMAL')).toBeVisible();
+    await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
+    await expect(page.getByLabel('Immune to ghost').getByText('GHOST')).toContainText('GHOST');
+});
+
+test('Hard code - Validate that ground icon and psychic icon Double Damage is showed to poison type', async ({ page }) => {
+    await expect(page.getByLabel('Select Type')).toBeVisible();
+    await page.getByLabel('Select the type poison').click();
+    await expect(page.getByLabel('Switch to Info')).toBeVisible();
+    await page.getByLabel('Switch to Info').click();
+
+    await expect(page.getByLabel('White Screen').getByText('POISON')).toBeVisible();
+    await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
+    await expect(page.getByRole('img', { name: 'ground icon' })).toBeVisible();
+    await expect(page.getByRole('img', { name: 'psychic icon' })).toBeVisible();
+});
+
+test.describe('Verify in batch the correct display of type information', () => {
+    TYPES.forEach((type) => {
+        let selectType = 'Select the type ' + type.name;
+        let icon = type.doubleDamage + ' icon';
+        let immune = 'Immune to ' + type.immune;
+        test(`Validate that Double Damage is showed to ${type.name} type`, async ({ page }) => {
+            await expect(page.getByLabel('Select Type')).toBeVisible();
+            await page.getByLabel(selectType).click();
+            await expect(page.getByLabel('Switch to Info')).toBeVisible();
+            await page.getByLabel('Switch to Info').click();
+
+            await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toContainText(type.name.toUpperCase());
+            await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
+            await expect(page.getByRole('img', { name: icon }).first()).toBeVisible();
+        });
+
+        test(`Validate that Immune to ${type.immune} is showed to ${type.name} type`, async ({ page }) => {
+            test.skip(type.immune == " " || type.immune == undefined);
+            await expect(page.getByLabel('Select Type')).toBeVisible();
+            await page.getByLabel(selectType).click();
+            await expect(page.getByLabel('Switch to Info')).toBeVisible();
+            await page.getByLabel('Switch to Info').click();
+
+            await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toBeVisible();
+            await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
+            await expect(page.getByLabel(immune).getByText(type.immune.toUpperCase())).toContainText(type.immune.toUpperCase());
+        });
+    });
+});
+
+
+
+


### PR DESCRIPTION
- Adicionei aos arquivos de configuração o "allure-playwright", para os relatórios.
-  Inseri o beforeEach para ficar mais legível os passos dentro de cada teste e evitar repetição do código
- Nos meus testes para tipo deixei 3 inserindo os locator e informações de forma direta no código como exemplo.
- Já para a validação em lote:
  - Adicionei o teste.describe para facilitar a compreensão de que estes testes foram realizados utilizando o forEach;
  - Como havia te dito por enquanto inseri os dados para tipo de forma manual, para que seja mais fácil a compreensão.
  - Para ficar mais simples a análise dos casos de teste onde o tipo não apresentava a informação imunidade eu inseri o teste.skip(condição)