### PR TITLE
Page object model

### DIFF
--- a/Data/types.js
+++ b/Data/types.js
@@ -32,7 +32,7 @@ export const TYPES = [
     },
     {
         "name": "ghost",
-        "doubleDamage": "ghost",
+        "doubleDamage": "dark",
         "immune": "normal"
     },
     {

--- a/pages/POManager.js
+++ b/pages/POManager.js
@@ -1,0 +1,14 @@
+const { Type } = require('./type')
+const { Homepage } = require('./homepage')
+
+class POManager {
+    constructor( page) {
+        this.page = page;
+        this.homepage = new Homepage(this.page);
+        this.type = new Type(this.page);
+    }
+    getHomePage() { return this.homepage; }
+    getTypePage() { return this.type; }
+}
+
+module.exports = { POManager };

--- a/pages/POManager.js
+++ b/pages/POManager.js
@@ -1,14 +1,20 @@
-const { Type } = require('./type')
-const { Homepage } = require('./homepage')
+const { Type } = require('./type');
+const { Homepage } = require('./homepage');
 
 class POManager {
-    constructor( page) {
-        this.page = page;
-        this.homepage = new Homepage(this.page);
-        this.type = new Type(this.page);
-    }
-    getHomePage() { return this.homepage; }
-    getTypePage() { return this.type; }
+  constructor(page) {
+    this.page = page;
+    this.homepage = new Homepage(this.page);
+    this.type = new Type(this.page);
+  }
+
+  getHomePage() {
+    return this.homepage;
+  }
+
+  getTypePage() {
+    return this.type;
+  }
 }
 
 module.exports = { POManager };

--- a/pages/homepage.js
+++ b/pages/homepage.js
@@ -1,50 +1,70 @@
 const { expect } = require('@playwright/test');
+
 class Homepage {
-    constructor (page) {
-        this.page = page;
-        this.pokemon = page.getByLabel('POKÉMON Button');
-        this.types = page.getByLabel('TYPES Button');
-        this.items = page.getByLabel('ITEMS Button');
-        this.regions = page.getByLabel('REGIONS Button');
-        this.fossils = page.getByLabel('FOSSILS Button');
-        this.photoBtn =  page.getByLabel('Switch to Photo');
-        this.infoBtn = page.getByLabel('Switch to Info');
-        this.gifPikachu = page.getByLabel('Animated Pikachu GIF');
-        this.gitHubRedirect = page.getByLabel('Redirect to GitHub account');
-    }
-    async navegateToUrl (url) { await this.page.goto('');}
-    async clickBntPokemon (){
-        await this.pokemon.click();
-    } 
-    async clickBntTypes (){
-        expect(this.types).toBeVisible();
-        await this.types.click();
-    }
-    async clickBntItems (){
-        await this.items.click();
-    }
-    async clickBntRegions (){
-        await this.regions.click();
-    }
-    async clickBntFossils (){
-        await this.fossils.click();
-    }
-    async clickBntPhoto (){
-        await this.photoBtn.click();
-    }
-    async clickBntInfo (){
-        await this.infoBtn.click();
-    }
-    async validateBtnTypesIsVisible() {
-        expect(this.types).toBeVisible();
-    }
-    async validateHomePage() {
-        expect(this.photoBtn).toBeVisible();
-        expect(this.infoBtn).toBeVisible();
-        expect(this.infoBtn).toHaveRole('button');
-        expect(this.types).toHaveText('TYPES');
-        expect
-    }
+  constructor(page) {
+    this.page = page;
+    this.pokemon = page.getByLabel('POKÉMON Button');
+    this.types = page.getByLabel('TYPES Button');
+    this.items = page.getByLabel('ITEMS Button');
+    this.regions = page.getByLabel('REGIONS Button');
+    this.fossils = page.getByLabel('FOSSILS Button');
+    this.photoBtn = page.getByLabel('Switch to Photo');
+    this.infoBtn = page.getByLabel('Switch to Info');
+    this.gifPikachu = page.getByLabel('Animated Pikachu GIF');
+    this.gitHubRedirect = page.getByLabel('Redirect to GitHub account');
+  }
+
+  // Actions
+  async navigateToUrl() {
+    await this.page.goto('');
+  }
+
+  async clickBntPokemon() {
+    await expect(this.pokemon).toBeVisible();
+    await this.pokemon.click();
+  }
+
+  async clickBntTypes() {
+    await expect(this.types).toBeVisible();
+    await this.types.click();
+  }
+
+  async clickBntItems() {
+    await expect(this.items).toBeVisible();
+    await this.items.click();
+  }
+
+  async clickBntRegions() {
+    await expect(this.regions).toBeVisible();
+    await this.regions.click();
+  }
+
+  async clickBntFossils() {
+    await expect(this.fossils).toBeVisible();
+    await this.fossils.click();
+  }
+
+  async clickBntPhoto() {
+    await expect(this.photoBtn).toBeVisible();
+    await this.photoBtn.click();
+  }
+
+  async clickBntInfo() {
+    await expect(this.infoBtn).toBeVisible();
+    await this.infoBtn.click();
+  }
+
+  // Validations
+  async validateBtnTypesIsVisible() {
+    await expect(this.types).toBeVisible();
+  }
+
+  async validateHomePage() {
+    await expect(this.photoBtn).toBeVisible();
+    await expect(this.infoBtn).toBeVisible();
+    await expect(this.infoBtn).toHaveRole('button');
+    await expect(this.types).toHaveText('TYPES');
+  }
 }
 
-module.exports = { Homepage }
+module.exports = { Homepage };

--- a/pages/homepage.js
+++ b/pages/homepage.js
@@ -17,6 +17,7 @@ class Homepage {
         await this.pokemon.click();
     } 
     async clickBntTypes (){
+        expect(this.types).toBeVisible();
         await this.types.click();
     }
     async clickBntItems (){
@@ -34,13 +35,16 @@ class Homepage {
     async clickBntInfo (){
         await this.infoBtn.click();
     }
+    async validateBtnTypesIsVisible() {
+        expect(this.types).toBeVisible();
+    }
     async validateHomePage() {
-        expect(this.pokemon).toBeVisible();
+        expect(this.photoBtn).toBeVisible();
         expect(this.infoBtn).toBeVisible();
         expect(this.infoBtn).toHaveRole('button');
-        expect(this.types).toHaveText('TYPES')
+        expect(this.types).toHaveText('TYPES');
+        expect
     }
-
 }
 
 module.exports = { Homepage }

--- a/pages/homepage.js
+++ b/pages/homepage.js
@@ -1,0 +1,46 @@
+const { expect } = require('@playwright/test');
+class Homepage {
+    constructor (page) {
+        this.page = page;
+        this.pokemon = page.getByLabel('POKÉMON Button');
+        this.types = page.getByLabel('TYPES Button');
+        this.items = page.getByLabel('ITEMS Button');
+        this.regions = page.getByLabel('REGIONS Button');
+        this.fossils = page.getByLabel('FOSSILS Button');
+        this.photoBtn =  page.getByLabel('Switch to Photo');
+        this.infoBtn = page.getByLabel('Switch to Info');
+        this.gifPikachu = page.getByLabel('Animated Pikachu GIF');
+        this.gitHubRedirect = page.getByLabel('Redirect to GitHub account');
+    }
+    async navegateToUrl (url) { await this.page.goto('');}
+    async clickBntPokemon (){
+        await this.pokemon.click();
+    } 
+    async clickBntTypes (){
+        await this.types.click();
+    }
+    async clickBntItems (){
+        await this.items.click();
+    }
+    async clickBntRegions (){
+        await this.regions.click();
+    }
+    async clickBntFossils (){
+        await this.fossils.click();
+    }
+    async clickBntPhoto (){
+        await this.photoBtn.click();
+    }
+    async clickBntInfo (){
+        await this.infoBtn.click();
+    }
+    async validateHomePage() {
+        expect(this.pokemon).toBeVisible();
+        expect(this.infoBtn).toBeVisible();
+        expect(this.infoBtn).toHaveRole('button');
+        expect(this.types).toHaveText('TYPES')
+    }
+
+}
+
+module.exports = { Homepage }

--- a/pages/type.js
+++ b/pages/type.js
@@ -1,54 +1,82 @@
 const { expect } = require('@playwright/test');
+import { Page } from "@playwright/test";
 class Type {
+
     constructor(page) {
         this.page = page;
-        this.searchType =
-            this.selectType = page.getByLabel('Select Type');
-        this.chooseType = page.getByLabel('Select the type normal');
-        this.typeName = page.getByLabel('White Screen').getByText('NORMAL');
-        this.typeDoubleDamageFrom = page.getByText('DOUBLE DAMAGEFROM:');
-        this.iconDoubleDamageFrom = page.getByRole('img', { name: 'fighting icon' });
+        this.selectTypeText = page.getByLabel('Select Type');
+        this.chooseTypeNormal = page.getByLabel('Select the type normal');
+        this.typeNormal = page.getByLabel('White Screen').getByText('NORMAL');
+        this.TypeDoubleDamageFrom = page.getByText('DOUBLE DAMAGEFROM:');
+        this.normalIconDoubleDamageFrom = page.getByRole('img', { name: 'fighting icon' });
         this.imunities = page.getByText('IMUNITIES');
-        this.immuneTo = page.getByLabel('Immune to ghost').getByText('GHOST');
+        this.normalImmuneTo = page.getByLabel('Immune to ghost').getByText('GHOST');
+        
     }
     async validateTypeInfoIsLoadAfterClick() {
-        expect(this.selectType).toBeVisible();
+        expect(this.selectTypeText).toBeVisible();
     }
-    // locators (type){
-    //     selectType = 'Select the type ' + type.typeName;
-    //     icon = type.doubleDamage + ' icon';
-    //     immune = 'Immune to ' + type.mmune;
-    // }
-    // selectTypeLocator(typeName) {
-    //     selectType = 'Select the type ' + typeName;
-    // }
-    // typeIcon(doubleDamage) {
-    //     icon = doubleDamage + ' icon';
-    // }
-    // immune(immune) {
-    //     immune = 'Immune to ' + immune;
-    // }
+    
+    selectTypeLocator(typeName) {
+        let selectType = 'Select the type ' + typeName;
+        let chooseType = this.page.getByLabel(selectType);
+        return chooseType;
+    }
+    typeLocator(typeName){
+        let type = this.page.getByLabel('White Screen').getByText(typeName.toUpperCase());
+        return type;
+    }
+    typeIcon(doubleDamage) {
+        let icon = doubleDamage + ' icon';
+        let iconDoubleDamageFrom = this.page.getByRole('img', { name: icon });
+        return iconDoubleDamageFrom;
+    }
+    immuneLocator(immune) {
+        let immuneLabel = 'Immune to ' + immune;
+        let immuneTo = this.page.getByLabel(immuneLabel).getByText(immune.toUpperCase());
+        return immuneTo;
+    }
 
     async waitElementIsVisible(element) {
         await element.waitFor();
     }
-    async clickOnSelectType() {
-        this.waitElementIsVisible(this.chooseType);
-        await this.chooseType.click();
+    async clickOnSelectNormalType() {
+        this.waitElementIsVisible(this.chooseTypeNormal);
+        await this.chooseTypeNormal.click();
     }
-    async verifyTypeInfoToDoubleDamage() {
-        expect(this.typeName).toBeVisible();
-        await this.typeDoubleDamageFrom.waitFor();
-        expect(this.typeDoubleDamageFrom).toBeVisible();
-        await this.iconDoubleDamageFrom.waitFor();
-        expect(this.iconDoubleDamageFrom).toBeVisible();
+    async verifyNormalTypeInfoToDoubleDamage() {
+        expect(this.typeNormal).toBeVisible();
+        await this.TypeDoubleDamageFrom.waitFor();
+        expect(this.TypeDoubleDamageFrom).toBeVisible();
+        await this.normalIconDoubleDamageFrom.waitFor();
+        expect(this.normalIconDoubleDamageFrom).toBeVisible();
     }
-    async verifyTypeInfoToImmune() {
-        expect(this.typeName).toBeVisible();
+    async verifyNormalTypeInfoToImmune() {
+        expect(this.typeNormal).toBeVisible();
         await this.imunities.waitFor();
         expect(this.imunities).toContainText('IMUNITIES');
-        await this.immuneTo.waitFor();
-        expect(this.immuneTo).toContainText('GHOST');
+        await this.normalImmuneTo.waitFor();
+        expect(this.normalImmuneTo).toContainText('GHOST');
+    }
+    async clickOnSelectType(typeName) {
+        let chooseType = this.selectTypeLocator(typeName);
+        this.waitElementIsVisible(chooseType);
+        await chooseType.click();
+    }
+    async verifyTypeInfoToDoubleDamage(typeName, doubleDamage) {
+        let type = this.typeLocator(typeName);
+        let iconDoubleDamageFrom = this.typeIcon(doubleDamage);
+        this.waitElementIsVisible(type);
+        expect(type).toBeVisible();
+        await this.waitElementIsVisible(iconDoubleDamageFrom);
+        expect(iconDoubleDamageFrom).toBeVisible();
+    }
+    async verifyTypeInfoToImmune(immune) {
+        let immuneTo = this.immuneLocator(immune);
+        await this.imunities.waitFor();
+        expect(this.imunities).toContainText('IMUNITIES');
+        await this.waitElementIsVisible(immuneTo);
+        expect(immuneTo).toContainText(immune.toUpperCase());
     }
 }
 

--- a/pages/type.js
+++ b/pages/type.js
@@ -1,0 +1,55 @@
+const { expect } = require('@playwright/test');
+class Type {
+    constructor(page) {
+        this.page = page;
+        this.searchType =
+            this.selectType = page.getByLabel('Select Type');
+        this.chooseType = page.getByLabel('Select the type normal');
+        this.typeName = page.getByLabel('White Screen').getByText('NORMAL');
+        this.typeDoubleDamageFrom = page.getByText('DOUBLE DAMAGEFROM:');
+        this.iconDoubleDamageFrom = page.getByRole('img', { name: 'fighting icon' });
+        this.imunities = page.getByText('IMUNITIES');
+        this.immuneTo = page.getByLabel('Immune to ghost').getByText('GHOST');
+    }
+    async validateTypeInfoIsLoadAfterClick() {
+        expect(this.selectType).toBeVisible();
+    }
+    // locators (type){
+    //     selectType = 'Select the type ' + type.typeName;
+    //     icon = type.doubleDamage + ' icon';
+    //     immune = 'Immune to ' + type.mmune;
+    // }
+    // selectTypeLocator(typeName) {
+    //     selectType = 'Select the type ' + typeName;
+    // }
+    // typeIcon(doubleDamage) {
+    //     icon = doubleDamage + ' icon';
+    // }
+    // immune(immune) {
+    //     immune = 'Immune to ' + immune;
+    // }
+
+    async waitElementIsVisible(element) {
+        await element.waitFor();
+    }
+    async clickOnSelectType() {
+        this.waitElementIsVisible(this.chooseType);
+        await this.chooseType.click();
+    }
+    async verifyTypeInfoToDoubleDamage() {
+        expect(this.typeName).toBeVisible();
+        await this.typeDoubleDamageFrom.waitFor();
+        expect(this.typeDoubleDamageFrom).toBeVisible();
+        await this.iconDoubleDamageFrom.waitFor();
+        expect(this.iconDoubleDamageFrom).toBeVisible();
+    }
+    async verifyTypeInfoToImmune() {
+        expect(this.typeName).toBeVisible();
+        await this.imunities.waitFor();
+        expect(this.imunities).toContainText('IMUNITIES');
+        await this.immuneTo.waitFor();
+        expect(this.immuneTo).toContainText('GHOST');
+    }
+}
+
+module.exports = { Type }

--- a/pages/type.js
+++ b/pages/type.js
@@ -1,83 +1,85 @@
 const { expect } = require('@playwright/test');
-import { Page } from "@playwright/test";
+
 class Type {
+  constructor(page) {
+    this.page = page;
+    this.selectTypeText = page.getByLabel('Select Type');
+    this.chooseTypeNormal = page.getByLabel('Select the type normal');
+    this.typeNormal = page.getByLabel('White Screen').getByText('NORMAL');
+    this.TypeDoubleDamageFrom = page.getByText('DOUBLE DAMAGEFROM:');
+    this.normalIconDoubleDamageFrom = page.getByRole('img', {
+      name: 'fighting icon',
+    });
+    this.imunities = page.getByText('IMUNITIES');
+    this.normalImmuneTo = page.getByLabel('Immune to ghost').getByText('GHOST');
+  }
 
-    constructor(page) {
-        this.page = page;
-        this.selectTypeText = page.getByLabel('Select Type');
-        this.chooseTypeNormal = page.getByLabel('Select the type normal');
-        this.typeNormal = page.getByLabel('White Screen').getByText('NORMAL');
-        this.TypeDoubleDamageFrom = page.getByText('DOUBLE DAMAGEFROM:');
-        this.normalIconDoubleDamageFrom = page.getByRole('img', { name: 'fighting icon' });
-        this.imunities = page.getByText('IMUNITIES');
-        this.normalImmuneTo = page.getByLabel('Immune to ghost').getByText('GHOST');
-        
-    }
-    async validateTypeInfoIsLoadAfterClick() {
-        expect(this.selectTypeText).toBeVisible();
-    }
-    
-    selectTypeLocator(typeName) {
-        let selectType = 'Select the type ' + typeName;
-        let chooseType = this.page.getByLabel(selectType);
-        return chooseType;
-    }
-    typeLocator(typeName){
-        let type = this.page.getByLabel('White Screen').getByText(typeName.toUpperCase());
-        return type;
-    }
-    typeIcon(doubleDamage) {
-        let icon = doubleDamage + ' icon';
-        let iconDoubleDamageFrom = this.page.getByRole('img', { name: icon });
-        return iconDoubleDamageFrom;
-    }
-    immuneLocator(immune) {
-        let immuneLabel = 'Immune to ' + immune;
-        let immuneTo = this.page.getByLabel(immuneLabel).getByText(immune.toUpperCase());
-        return immuneTo;
-    }
+  // Locators
+  selectTypeLocator(typeName) {
+    return this.page.getByLabel(`Select the type ${typeName}`);
+  }
 
-    async waitElementIsVisible(element) {
-        await element.waitFor();
-    }
-    async clickOnSelectNormalType() {
-        this.waitElementIsVisible(this.chooseTypeNormal);
-        await this.chooseTypeNormal.click();
-    }
-    async verifyNormalTypeInfoToDoubleDamage() {
-        expect(this.typeNormal).toBeVisible();
-        await this.TypeDoubleDamageFrom.waitFor();
-        expect(this.TypeDoubleDamageFrom).toBeVisible();
-        await this.normalIconDoubleDamageFrom.waitFor();
-        expect(this.normalIconDoubleDamageFrom).toBeVisible();
-    }
-    async verifyNormalTypeInfoToImmune() {
-        expect(this.typeNormal).toBeVisible();
-        await this.imunities.waitFor();
-        expect(this.imunities).toContainText('IMUNITIES');
-        await this.normalImmuneTo.waitFor();
-        expect(this.normalImmuneTo).toContainText('GHOST');
-    }
-    async clickOnSelectType(typeName) {
-        let chooseType = this.selectTypeLocator(typeName);
-        this.waitElementIsVisible(chooseType);
-        await chooseType.click();
-    }
-    async verifyTypeInfoToDoubleDamage(typeName, doubleDamage) {
-        let type = this.typeLocator(typeName);
-        let iconDoubleDamageFrom = this.typeIcon(doubleDamage);
-        this.waitElementIsVisible(type);
-        expect(type).toBeVisible();
-        await this.waitElementIsVisible(iconDoubleDamageFrom);
-        expect(iconDoubleDamageFrom).toBeVisible();
-    }
-    async verifyTypeInfoToImmune(immune) {
-        let immuneTo = this.immuneLocator(immune);
-        await this.imunities.waitFor();
-        expect(this.imunities).toContainText('IMUNITIES');
-        await this.waitElementIsVisible(immuneTo);
-        expect(immuneTo).toContainText(immune.toUpperCase());
-    }
+  typeLocator(typeName) {
+    return this.page
+      .getByLabel('White Screen')
+      .getByText(typeName.toUpperCase());
+  }
+
+  typeIcon(doubleDamage) {
+    return this.page.getByRole('img', { name: `${doubleDamage} icon` });
+  }
+
+  immuneLocator(immune) {
+    return this.page
+      .getByLabel(`Immune to ${immune}`)
+      .getByText(immune.toUpperCase());
+  }
+
+  // Actions
+  async clickOnSelectNormalType() {
+    await expect(this.chooseTypeNormal).toBeVisible();
+    await this.chooseTypeNormal.click();
+  }
+
+  async clickOnSelectType(typeName) {
+    const chooseType = this.selectTypeLocator(typeName);
+    await expect(chooseType).toBeVisible();
+    await chooseType.click();
+  }
+
+  // Validations
+  async validateTypeInfoIsLoadAfterClick() {
+    await expect(this.selectTypeText).toBeVisible();
+  }
+
+  async verifyNormalTypeInfoToDoubleDamage() {
+    await expect(this.typeNormal).toBeVisible();
+    await expect(this.TypeDoubleDamageFrom).toBeVisible();
+    await expect(this.normalIconDoubleDamageFrom).toBeVisible();
+  }
+
+  async verifyNormalTypeInfoToImmune() {
+    await expect(this.typeNormal).toBeVisible();
+    await expect(this.imunities).toBeVisible();
+    await expect(this.imunities).toContainText('IMUNITIES');
+    await expect(this.normalImmuneTo).toBeVisible();
+    await expect(this.normalImmuneTo).toContainText('GHOST');
+  }
+
+  async verifyTypeInfoToDoubleDamage(typeName, doubleDamage) {
+    const type = this.typeLocator(typeName);
+    const iconDoubleDamageFrom = this.typeIcon(doubleDamage);
+    await expect(type).toBeVisible();
+    await expect(iconDoubleDamageFrom).toBeVisible();
+  }
+
+  async verifyTypeInfoToImmune(immune) {
+    const immuneTo = this.immuneLocator(immune);
+    await expect(this.imunities).toBeVisible();
+    await expect(this.imunities).toContainText('IMUNITIES');
+    await expect(immuneTo).toBeVisible();
+    await expect(immuneTo).toContainText(immune.toUpperCase());
+  }
 }
 
-module.exports = { Type }
+module.exports = { Type };

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,6 +34,7 @@ module.exports = defineConfig({
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    baseURL: 'https://brunomachadors.github.io/pokedex/',
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -34,9 +34,8 @@ module.exports = defineConfig({
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    baseURL: 'https://brunomachadors.github.io/pokedex/',
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'https://brunomachadors.github.io/pokedex/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -1,9 +1,9 @@
 const { test } = require('@playwright/test');
 const { POManager } = require('../pages/POManager');
 
-test( 'Validate home', async ({page}) =>{
-    const poManager = new POManager(page);
-    const homepage = poManager.getHomePage();
-    await homepage.navegateToUrl();
-    await homepage.validateHomePage();
-})
+test('Validate home', async ({ page }) => {
+  const poManager = new POManager(page);
+  const homepage = poManager.getHomePage();
+  await homepage.navigateToUrl();
+  await homepage.validateHomePage();
+});

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -5,6 +5,5 @@ test( 'Validate home', async ({page}) =>{
     const poManager = new POManager(page);
     const homepage = poManager.getHomePage();
     await homepage.navegateToUrl();
-    await homepage.clickBntPokemon();
     await homepage.validateHomePage();
 })

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -1,0 +1,10 @@
+const { test } = require('@playwright/test');
+const { POManager } = require('../pages/POManager');
+
+test( 'Validate home', async ({page}) =>{
+    const poManager = new POManager(page);
+    const homepage = poManager.getHomePage();
+    await homepage.navegateToUrl();
+    await homepage.clickBntPokemon();
+    await homepage.validateHomePage();
+})

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -1,46 +1,34 @@
-import { skip } from 'node:test';
-import { TYPES } from '../Data/types';
-
 const { test, expect } = require('@playwright/test');
+import { TYPES } from '../Data/types';
+const { POManager } = require('../pages/POManager');
 
 test.beforeEach(async ({ page }) => {
-    await page.goto('https://brunomachadors.github.io/pokedex/');
-    await expect(page.getByLabel('TYPES Button')).toBeVisible();
-    await page.getByLabel('TYPES Button').click();
+    const poManager = new POManager(page);
+    const homepage = poManager.getHomePage();
+    const type = poManager.getTypePage();
+    await homepage.navegateToUrl();
+    await homepage.clickBntTypes();
+    await type.validateTypeInfoIsLoadAfterClick();
 });
 
 test('Hard code - Validate that fighting icon Double Damage is showed to normal type', async ({ page }) => {
-    await expect(page.getByLabel('Select Type')).toBeVisible();
-    await page.getByLabel('Select the type normal').click();
-    await expect(page.getByLabel('Switch to Info')).toBeVisible();
-    await page.getByLabel('Switch to Info').click();
+    const poManager = new POManager(page);
+    const homepage = poManager.getHomePage();
+    const type = poManager.getTypePage();
 
-    await expect(page.getByLabel('White Screen').getByText('NORMAL')).toBeVisible();
-    await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
-    await expect(page.getByRole('img', { name: 'fighting icon' })).toBeVisible();
+    await homepage.clickBntInfo();
+    await type.clickOnSelectType();
+    await type.verifyTypeInfoToDoubleDamage();
 });
 
 test('Hard code - Validate that Immune to ghost is showed to normal type', async ({ page }) => {
-    await expect(page.getByLabel('Select Type')).toBeVisible();
-    await page.getByLabel('Select the type normal').click();
-    await expect(page.getByLabel('Switch to Info')).toBeVisible();
-    await page.getByLabel('Switch to Info').click();
+    const poManager = new POManager(page);
+    const homepage = poManager.getHomePage();
+    const type = poManager.getTypePage();
 
-    await expect(page.getByLabel('White Screen').getByText('NORMAL')).toBeVisible();
-    await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
-    await expect(page.getByLabel('Immune to ghost').getByText('GHOST')).toContainText('GHOST');
-});
-
-test('Hard code - Validate that ground icon and psychic icon Double Damage is showed to poison type', async ({ page }) => {
-    await expect(page.getByLabel('Select Type')).toBeVisible();
-    await page.getByLabel('Select the type poison').click();
-    await expect(page.getByLabel('Switch to Info')).toBeVisible();
-    await page.getByLabel('Switch to Info').click();
-
-    await expect(page.getByLabel('White Screen').getByText('POISON')).toBeVisible();
-    await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
-    await expect(page.getByRole('img', { name: 'ground icon' })).toBeVisible();
-    await expect(page.getByRole('img', { name: 'psychic icon' })).toBeVisible();
+    await homepage.clickBntInfo();
+    await type.clickOnSelectType();
+    await type.verifyTypeInfoToImmune();
 });
 
 test.describe('Verify in batch the correct display of type information', () => {

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test } = require('@playwright/test');
 import { TYPES } from '../Data/types';
 const { POManager } = require('../pages/POManager');
 
@@ -17,8 +17,8 @@ test('Hard code - Validate that fighting icon Double Damage is showed to normal 
     const type = poManager.getTypePage();
 
     await homepage.clickBntInfo();
-    await type.clickOnSelectType();
-    await type.verifyTypeInfoToDoubleDamage();
+    await type.clickOnSelectNormalType();
+    await type.verifyNormalTypeInfoToDoubleDamage();
 });
 
 test('Hard code - Validate that Immune to ghost is showed to normal type', async ({ page }) => {
@@ -27,42 +27,33 @@ test('Hard code - Validate that Immune to ghost is showed to normal type', async
     const type = poManager.getTypePage();
 
     await homepage.clickBntInfo();
-    await type.clickOnSelectType();
-    await type.verifyTypeInfoToImmune();
+    await type.clickOnSelectNormalType();
+    await type.verifyNormalTypeInfoToImmune();
 });
 
 test.describe('Verify in batch the correct display of type information', () => {
     TYPES.forEach((type) => {
-        let selectType = 'Select the type ' + type.name;
-        let icon = type.doubleDamage + ' icon';
-        let immune = 'Immune to ' + type.immune;
+        let name = type.name;
+        let doubleDamage = type.doubleDamage;
         test(`Validate that Double Damage is showed to ${type.name} type`, async ({ page }) => {
-            await expect(page.getByLabel('Select Type')).toBeVisible();
-            await page.getByLabel(selectType).click();
-            await expect(page.getByLabel('Switch to Info')).toBeVisible();
-            await page.getByLabel('Switch to Info').click();
-
-            await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toContainText(type.name.toUpperCase());
-            await expect(page.getByText('DOUBLE DAMAGEFROM:')).toBeVisible();
-            await expect(page.getByRole('img', { name: icon }).first()).toBeVisible();
+            const poManager = new POManager(page);
+            const homepage = poManager.getHomePage();
+            const type = poManager.getTypePage();
+            await type.clickOnSelectType(name);
+            await homepage.clickBntInfo();
+            await type.verifyTypeInfoToDoubleDamage(name, doubleDamage);
         });
         const isImmune = type.immune ? true : false;
         if (isImmune) {
+            let immune = type.immune;
             test(`Validate that Immune to ${type.immune} is showed to ${type.name} type`, async ({ page }) => {
-                test.skip(type.immune == " " || type.immune == undefined);
-                await expect(page.getByLabel('Select Type')).toBeVisible();
-                await page.getByLabel(selectType).click();
-                await expect(page.getByLabel('Switch to Info')).toBeVisible();
-                await page.getByLabel('Switch to Info').click();
-
-                await expect(page.getByLabel('White Screen').getByText(type.name.toUpperCase())).toBeVisible();
-                await expect(page.getByText('IMUNITIES')).toContainText('IMUNITIES');
-                await expect(page.getByLabel(immune).getByText(type.immune.toUpperCase())).toContainText(type.immune.toUpperCase());
+                const poManager = new POManager(page);
+                const homepage = poManager.getHomePage();
+                const type = poManager.getTypePage();
+                await type.clickOnSelectType(name);
+                await homepage.clickBntInfo();
+                await type.verifyTypeInfoToImmune(immune);
             });
         }
     });
 });
-
-
-
-

--- a/tests/type.spec.js
+++ b/tests/type.spec.js
@@ -3,57 +3,65 @@ import { TYPES } from '../Data/types';
 const { POManager } = require('../pages/POManager');
 
 test.beforeEach(async ({ page }) => {
-    const poManager = new POManager(page);
-    const homepage = poManager.getHomePage();
-    const type = poManager.getTypePage();
-    await homepage.navegateToUrl();
-    await homepage.clickBntTypes();
-    await type.validateTypeInfoIsLoadAfterClick();
+  const poManager = new POManager(page);
+  const homepage = poManager.getHomePage();
+  const type = poManager.getTypePage();
+  await homepage.navigateToUrl();
+  await homepage.clickBntTypes();
+  await type.validateTypeInfoIsLoadAfterClick();
 });
 
-test('Hard code - Validate that fighting icon Double Damage is showed to normal type', async ({ page }) => {
-    const poManager = new POManager(page);
-    const homepage = poManager.getHomePage();
-    const type = poManager.getTypePage();
+test('Hard code - Validate that fighting icon Double Damage is shown to normal type', async ({
+  page,
+}) => {
+  const poManager = new POManager(page);
+  const homepage = poManager.getHomePage();
+  const type = poManager.getTypePage();
 
-    await homepage.clickBntInfo();
-    await type.clickOnSelectNormalType();
-    await type.verifyNormalTypeInfoToDoubleDamage();
+  await homepage.clickBntInfo();
+  await type.clickOnSelectNormalType();
+  await type.verifyNormalTypeInfoToDoubleDamage();
 });
 
-test('Hard code - Validate that Immune to ghost is showed to normal type', async ({ page }) => {
-    const poManager = new POManager(page);
-    const homepage = poManager.getHomePage();
-    const type = poManager.getTypePage();
+test('Hard code - Validate that Immune to ghost is shown to normal type', async ({
+  page,
+}) => {
+  const poManager = new POManager(page);
+  const homepage = poManager.getHomePage();
+  const type = poManager.getTypePage();
 
-    await homepage.clickBntInfo();
-    await type.clickOnSelectNormalType();
-    await type.verifyNormalTypeInfoToImmune();
+  await homepage.clickBntInfo();
+  await type.clickOnSelectNormalType();
+  await type.verifyNormalTypeInfoToImmune();
 });
 
 test.describe('Verify in batch the correct display of type information', () => {
-    TYPES.forEach((type) => {
-        let name = type.name;
-        let doubleDamage = type.doubleDamage;
-        test(`Validate that Double Damage is showed to ${type.name} type`, async ({ page }) => {
-            const poManager = new POManager(page);
-            const homepage = poManager.getHomePage();
-            const type = poManager.getTypePage();
-            await type.clickOnSelectType(name);
-            await homepage.clickBntInfo();
-            await type.verifyTypeInfoToDoubleDamage(name, doubleDamage);
-        });
-        const isImmune = type.immune ? true : false;
-        if (isImmune) {
-            let immune = type.immune;
-            test(`Validate that Immune to ${type.immune} is showed to ${type.name} type`, async ({ page }) => {
-                const poManager = new POManager(page);
-                const homepage = poManager.getHomePage();
-                const type = poManager.getTypePage();
-                await type.clickOnSelectType(name);
-                await homepage.clickBntInfo();
-                await type.verifyTypeInfoToImmune(immune);
-            });
-        }
+  TYPES.forEach((type) => {
+    let name = type.name;
+    let doubleDamage = type.doubleDamage;
+    test(`Validate that Double Damage is shown to ${type.name} type`, async ({
+      page,
+    }) => {
+      const poManager = new POManager(page);
+      const homepage = poManager.getHomePage();
+      const type = poManager.getTypePage();
+      await type.clickOnSelectType(name);
+      await homepage.clickBntInfo();
+      await type.verifyTypeInfoToDoubleDamage(name, doubleDamage);
     });
+    const isImmune = type.immune ? true : false;
+    if (isImmune) {
+      let immune = type.immune;
+      test(`Validate that Immune to ${type.immune} is shown to ${type.name} type`, async ({
+        page,
+      }) => {
+        const poManager = new POManager(page);
+        const homepage = poManager.getHomePage();
+        const type = poManager.getTypePage();
+        await type.clickOnSelectType(name);
+        await homepage.clickBntInfo();
+        await type.verifyTypeInfoToImmune(immune);
+      });
+    }
+  });
 });


### PR DESCRIPTION
- Add POM to homepage and type;
- Simple test create to homepage;
- Ajust test of type to use POM; 
- In POM to type:
      - no construtor inseri os dados que seriam necessários para os testes;
      - para a criação dos locators da página de forma dinâmica, optei por utilizar um método, assim facilitando a manutenibilidade; 
      - criação do método waitElementVisible, pois estava dando erro quando o elemento levava mais tempo para ser carregado;
      - criação do método para clicar no tipo normal clickOnSelectNormalType(); verificar as informações de double damage para o tipo normal verifyNormalTypeInfoToDoubleDamage(); e validar as informações de imunidade para o tipo normal  verifyNormalTypeInfoToImmune()
      - posteriormente foram criados os métodos para a validação dinâmica de double damage( verifyTypeInfoToDoubleDamage(typeName, doubleDamage)) e imunidade(verifyTypeInfoToImmune(immune))

Para os testes dinâmicos foi utilizado uma variável local para passar os parâmetros de cada tipo, pois nesta formatação estava sendo passado como null. Optei por manter neste local a utilização das informações do array de tipos, pois desta forma mantinha a criação do nome dos testes dinâmico.